### PR TITLE
tty: serial: meson: allow baud-rates lower than 9600

### DIFF
--- a/drivers/tty/serial/meson_uart.c
+++ b/drivers/tty/serial/meson_uart.c
@@ -362,7 +362,7 @@ static void meson_uart_set_termios(struct uart_port *port,
 
 	writel(val, port->membase + AML_UART_CONTROL);
 
-	baud = uart_get_baud_rate(port, termios, old, 9600, 4000000);
+	baud = uart_get_baud_rate(port, termios, old, 50, 4000000);
 	meson_uart_change_speed(port, baud);
 
 	port->read_status_mask = AML_UART_TX_FIFO_WERR;


### PR DESCRIPTION
Devices like DCF77 receivers need the baud-rate to be as low as 50.

I have tested this on a Meson GXL device with uart_A.

Signed-off-by: V10lator <v10lator@myway.de>